### PR TITLE
fix: recorder systemd unit gives up permanently when NATS is slow to start at boot

### DIFF
--- a/install-files/plugnmeet-recorder.service
+++ b/install-files/plugnmeet-recorder.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=plugNmeet recorder
 Requires=network-online.target
-After=network-online.target remote-fs.target
-StartLimitIntervalSec=60
-StartLimitBurst=3
+# docker.service ordering: on all-in-one installs NATS runs in Docker and is not
+# ready when network-online.target is reached; this is a no-op on recorder-only
+# machines without Docker.
+After=network-online.target remote-fs.target docker.service
+# Never stop retrying: at boot the recorder can fail repeatedly while NATS is
+# still starting. With a start limit, systemd gives up permanently and the
+# recorder stays dead until someone restarts it by hand.
+StartLimitIntervalSec=0
 
 [Service]
 WorkingDirectory=/opt/plugNmeet/recorder

--- a/install-files/plugnmeet-recorder.service
+++ b/install-files/plugnmeet-recorder.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=plugNmeet recorder
 Requires=network-online.target
-# docker.service ordering: on all-in-one installs NATS runs in Docker and is not
-# ready when network-online.target is reached; this is a no-op on recorder-only
-# machines without Docker.
-After=network-online.target remote-fs.target docker.service
+# plugnmeet.service ordering: on all-in-one installs NATS runs in the Docker
+# compose stack started by plugnmeet.service, which is not up when
+# network-online.target is reached; this is a no-op on recorder-only machines
+# where plugnmeet.service does not exist.
+After=network-online.target remote-fs.target plugnmeet.service
 # Never stop retrying: at boot the recorder can fail repeatedly while NATS is
 # still starting. With a start limit, systemd gives up permanently and the
 # recorder stays dead until someone restarts it by hand.


### PR DESCRIPTION
## Problem

On an all-in-one install (recorder on the same host as the Docker stack), the recorder races NATS at boot:

1. systemd reaches `network-online.target` and starts `plugnmeet-recorder` before the dockerized NATS server is listening on `127.0.0.1:4222`.
2. The recorder exits with `failed to connect to NATS: nats: no servers available for connection` (or an i/o timeout).
3. With `StartLimitIntervalSec=60` / `StartLimitBurst=3` and `RestartSec=10`, three quick failures hit the start limit and systemd gives up permanently:

```
plugnmeet-recorder.service: Scheduled restart job, restart counter is at 3.
plugnmeet-recorder.service: Start request repeated too quickly.
plugnmeet-recorder.service: Failed with result 'exit-code'.
Failed to start plugnmeet-recorder.service - plugNmeet recorder.
```

The recorder then stays dead until someone restarts it by hand. Every cloud-recording attempt fails with **"Failed to add token for recording bot"** because `selectRecorder()` on the server finds no active recorder. We hit this in production after a routine server reboot: the recorder was down for two days before anyone noticed via the recording error.

## Fix

- `StartLimitIntervalSec=0` — never stop retrying. `Restart=always` + `RestartSec=10` already give a calm retry pace; the unit now simply keeps trying until NATS is up.
- `After=... docker.service` — shortens the wait on all-in-one installs by ordering the recorder after the Docker daemon. Ordering on a unit that does not exist is a no-op, so recorder-only machines without Docker are unaffected (`After=` adds no dependency, only ordering).